### PR TITLE
fix layouts in login, register, and user-info pages

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react'
 import pageStyles from './Page.module.css'
 
-import { useWindowSize } from 'react-use'
-
 import { useActionDispatchReducer, getRoot, genUUID, Empty } from 'react-reducer-utils'
 
 import { PTT_GUEST } from '../constants'
@@ -45,17 +43,11 @@ export default (props) => {
   let homePage = getRoot(stateHomePage) || {}
   let myID = homePage.id || ''
 
-  //render
-  const {height: innerHeight} = useWindowSize()
-  let style = {
-    height: innerHeight + 'px',
-  }
-
   if(!myID) {
     return (<Empty />)
   }
   return (
-    <div className={pageStyles['root']} style={style}>
+    <div className={'vh-100 ' + pageStyles['root']}>
       <Header title={''} stateHeader={stateHeader} />
     </div>
   )

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -4,8 +4,6 @@ import config from 'config'
 
 import * as errors from './errors'
 
-import { useWindowSize } from 'react-use'
-
 import { useActionDispatchReducer, getRoot, genUUID, Empty } from 'react-reducer-utils'
 
 import * as DoLoginPage from '../reducers/loginPage'
@@ -34,12 +32,6 @@ export default (props) => {
   let loginPage = getRoot(stateLoginPage) || {}
   let myID = loginPage.id || ''
   let errmsg = loginPage.errmsg || ''
-
-  //render
-  const {height: innerHeight} = useWindowSize()
-  let style = {
-    height: innerHeight + 'px',
-  }
 
   let cleanErr = () => {
     setErrMsg('')
@@ -79,9 +71,9 @@ export default (props) => {
     return (<Empty />)
   }
   return (
-    <div className={pageStyles['root']} style={style}>
+    <div className={'vh-100 ' + pageStyles['root']}>
       <Header title={headerTitle} stateHeader={stateHeader} />
-      <div className={'container mt-5 '} style={style}>
+      <div className={'container mt-5 '}>
         <div className="row">
           <div className="col-12 col-md-6 mx-auto">
 

--- a/src/components/RegisterPage.js
+++ b/src/components/RegisterPage.js
@@ -157,9 +157,9 @@ export default (props) => {
   }
 
   return (
-    <div className={pageStyles['root']}>
+    <div className={'vh-100 ' + pageStyles['root']}>
       <Header title={headerTitle} stateHeader={stateHeader} />
-      <div className='container vh-100 mt-4'>
+      <div className='container mt-4'>
         <div className="row">
           <div className="col-12 col-md-6 mx-auto">
 

--- a/src/components/UserInfoPage.js
+++ b/src/components/UserInfoPage.js
@@ -3,8 +3,6 @@ import pageStyles from './Page.module.css'
 
 import * as errors from './errors'
 
-import { useWindowSize } from 'react-use'
-
 import { useParams } from 'react-router-dom'
 
 import { useActionDispatchReducer, getRoot, genUUID, Empty } from 'react-reducer-utils'
@@ -39,12 +37,7 @@ export default (props) => {
   let myID = userPage.id || ''
   let errmsg = userPage.errmsg || ''
 
-  //render
-  const {height: innerHeight} = useWindowSize()
-  let style = {
-    height: innerHeight + 'px',
-  }
-
+  //actions
   let changePassword = () => {
     window.location.href = "/user/"+userid+"/resetpassword"
   }
@@ -102,9 +95,9 @@ export default (props) => {
     return (<Empty />)
   }
   return (
-    <div className={pageStyles['root']} style={style}>
+    <div className={'vh-100 ' + pageStyles['root']}>
       <Header title={headerTitle} stateHeader={stateHeader} />
-      <div className={'container'} style={style}>
+      <div className={'container'}>
         <div className='row'>
           <div className='col'>
             <label>我是 {userPage.username}({userPage.nickname}) {userPage.realname}</label>


### PR DESCRIPTION
Fix layouts to remove redundant white space below the pages.
Rather than assign height directly in js files, I use Bootstrap utility class to set page height to meet the window size.