### PR TITLE
Hotkeys: enable going back using left arrow key

### DIFF
--- a/src/components/ArticlePage.js
+++ b/src/components/ArticlePage.js
@@ -11,6 +11,7 @@ import { useActionDispatchReducer, getRoot, genUUID } from 'react-reducer-utils'
 import * as DoArticlePage from '../reducers/articlePage'
 import * as DoHeader from '../reducers/header'
 
+import HotKeys from './HotKeys'
 import Header from './Header'
 import FunctionBar from './FunctionBar'
 
@@ -105,6 +106,7 @@ export default (props) => {
 
   return (
     <div className={pageStyles['root']}>
+      <HotKeys parentPage={`/board/${bid}/articles`}>
       <div ref={headerRef}>
         <Header title={headerTitle} stateHeader={stateHeader} />
       </div>
@@ -112,6 +114,7 @@ export default (props) => {
       <div ref={funcbarRef}>
         <FunctionBar optionsLeft={loptions} optionsRight={roptions}/>
       </div>
+      </HotKeys>
     </div>
   )
 }

--- a/src/components/ArticlesPage.js
+++ b/src/components/ArticlesPage.js
@@ -11,11 +11,14 @@ import { useActionDispatchReducer, getRoot, genUUID } from 'react-reducer-utils'
 import * as DoArticlesPage from '../reducers/articlesPage'
 import * as DoHeader from '../reducers/header'
 
+import HotKeys from './HotKeys'
 import Header from './Header'
 import ArticleList from './ArticleList'
 import FunctionBar from './FunctionBar'
 
 import QueryString from 'query-string'
+
+import { GetBoardParent } from './utils'
 
 export default (props) => {
   const [stateArticlesPage, doArticlesPage] = useActionDispatchReducer(DoArticlesPage)
@@ -54,6 +57,8 @@ export default (props) => {
   //let nextCreateTime = articlesPage.nextCreateTime || 0
   let scrollToRow = (typeof articlesPage.scrollToRow === 'undefined') ? null : articlesPage.scrollToRow
   let articles = articlesPage.allArticles || []
+
+  let parentPage = GetBoardParent() || '/boards/popular'
 
   //render
   const [headerHeight, setHeaderHeight] = useState(0)
@@ -130,6 +135,7 @@ export default (props) => {
   // Will fail if used on React components.
   return (
     <div className={pageStyles['root']}>
+      <HotKeys parentPage={parentPage}>
       <div ref={headerRef}>
         <Header title={headerTitle} stateHeader={stateHeader} />
       </div>
@@ -137,6 +143,7 @@ export default (props) => {
       <div ref={funcbarRef}>
         <FunctionBar optionsLeft={loptions} optionsRight={roptions}/>
       </div>
+      </HotKeys>
     </div>
   )
 }

--- a/src/components/HotBoardsPage.js
+++ b/src/components/HotBoardsPage.js
@@ -12,6 +12,7 @@ import { PTT_GUEST } from '../constants'
 import * as DoHotBoardsPage from '../reducers/hotBoardsPage'
 import * as DoHeader from '../reducers/header'
 
+import HotKeys from './HotKeys'
 import Header from './Header'
 import BoardList from './BoardList'
 import FunctionBar from './FunctionBar'
@@ -91,6 +92,7 @@ export default (props) => {
   // Will fail if used on React components. e.g. Header
   return (
     <div className={pageStyles['root']}>
+      <HotKeys>
       <div ref={headerRef}>
         <Header title={headerTitle} stateHeader={stateHeader} />
       </div>
@@ -98,6 +100,7 @@ export default (props) => {
       <div ref={funcbarRef}>
         <FunctionBar optionsLeft={loptions} optionsRight={roptions}/>
       </div>
+      </HotKeys>
     </div>
   )
 }

--- a/src/components/HotKeys.js
+++ b/src/components/HotKeys.js
@@ -1,0 +1,14 @@
+import { useKey } from 'react-use'
+
+export default (props) => {
+  // default parent page: root
+  const {parentPage = '/'} = props
+
+  // Hotkeys can be extended
+  useKey('ArrowLeft', (e) => {
+    console.log('go back to ' + parentPage)
+    window.location.href = parentPage
+  })
+
+  return props.children
+}

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -28,3 +28,10 @@ export const CalcScreenScale = (width) => {
 
   return [scale, lineHeight, fontSize]
 }
+
+export const GetBoardParent = () => {
+  //TODO: imagine that there should be a session data remembering the last board list visited
+  // If the board is visited directly by url there will be no record => return ""
+  console.log("GetBoardParent:")
+  return ""
+}


### PR DESCRIPTION
## Why
Add left arrow hotkey.

## How
Using useKey hook.
Currently implemented for article/board, but it all goes back to /board/popular for board temporarily.
目前每個文章都會回到看板，但看版目前都暫訂回到熱門看板列表
需要之後增加紀錄 是從哪個看板列表進來看版的

## Related Issues
#91 
