### PR TITLE
url in bottom-articles

### DIFF
--- a/src/reducers/articlesPage.js
+++ b/src/reducers/articlesPage.js
@@ -46,8 +46,9 @@ const _getBottomArticles = (myID, bid) => {
       return
     }
 
-    let bottomArticles = data.list
+    let bottomArticles = data.list || []
     bottomArticles.map( each => each.numIdx = '★' )
+    bottomArticles.map((each) => each.url = `/board/${bid}/article/${each.aid}`)
 
     let state = getState()
     let me = getMe(state, myID)


### PR DESCRIPTION
## Why

url in bottom-articles should be /board/:bid/article/:aid, not /bbs/:bid/:aid.html

## How

setup url after receiving data from backend.

## Related Issues

## References
