### PR TITLE
feat: display of characters with two colors and text blinking

### DIFF
--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { Table, Column, Cell } from 'fixed-data-table-2'
 
 import styles from './Screen.module.css'
+import runeStyles from './cells/ContentRenderer.module.css'
 
 import { CalcScreenScale, BASE_COLUMN_WIDTH } from './utils'
 
@@ -14,8 +15,20 @@ const _DEFAULT_COLUMNS = [
   {Header: '', accessor: '', width: 0, fixed: true, 'type': 'rest'},
 ]
 
+const _initBlink = () => {
+  // The <body> blinking trick, inspired by PttChrome:
+  // https://github.com/robertabcd/PttChrome/blob/dev/src/js/term_buf.js TermBuf.prototype.notify()
+  const interval = setInterval(() => document.body.classList.toggle(runeStyles['hide-blink']), 1000)
+  return () => {
+    clearInterval(interval)
+    document.body.classList.remove(runeStyles['hide-blink'])
+  }
+}
+
 export default (props) => {
   const {width, height, columns: propsColumns, data, renderCell: propsRenderCell, renderHeader, scrollTop, onVerticalScroll, scrollToRow} = props
+
+  useEffect(_initBlink, [])
 
   let columns = propsColumns || _DEFAULT_COLUMNS
 

--- a/src/components/cells/ContentRenderer.js
+++ b/src/components/cells/ContentRenderer.js
@@ -44,36 +44,42 @@ export class Runes extends Component {
   }
 }
 
-export const RuneCore = (props) => {
-  const {rune, rowIndex, idx, onMouseDown} = props
-  let classNames0 = [styles['rune']]
-  let color0 = rune.color0 || {}
-  if(color0.foreground) {
-    if(color0.highlight) {
-      classNames0.push(styles['h'+color0.foreground])
-    } else {
-      classNames0.push(styles['c'+color0.foreground])
+export class RuneCore extends Component {
+  static getClassNamesFromRune = (rune) => {
+    let classNames0 = [styles['rune']]
+    let color0 = rune.color0 || {}
+    if(color0.foreground) {
+      if(color0.highlight) {
+        classNames0.push(styles['h'+color0.foreground])
+      } else {
+        classNames0.push(styles['c'+color0.foreground])
+      }
     }
-  }
-  if(color0.background) {
-    classNames0.push(styles['c'+color0.background])
-  }
-  if(rune.pullright){
-    classNames0.push(styles['pull-right'])
+    if(color0.background) {
+      classNames0.push(styles['c'+color0.background])
+    }
+    return classNames0
   }
 
-  let className0 = classNames0.join(' ')
-  let runeKey = 'rune-' + rowIndex + '-' + idx
-  let _onMouseDown = (e) => {
-    if(!onMouseDown) {
-      return
+  render = () => {
+    const {rune, rowIndex, idx, onMouseDown} = this.props
+    let classNames0 = RuneCore.getClassNamesFromRune(rune)
+    if(rune.pullright){
+      classNames0.push(styles['pull-right'])
     }
-    onMouseDown(e, rowIndex, idx)
-  }
+    let className0 = classNames0.join(' ')
+    let runeKey = 'rune-' + rowIndex + '-' + idx
+    let _onMouseDown = (e) => {
+      if(!onMouseDown) {
+        return
+      }
+      onMouseDown(e, rowIndex, idx)
+    }
 
-  return (
-    <span key={runeKey} className={className0} onMouseDown={_onMouseDown}>{rune.text}</span>
-  )
+    return (
+      <span key={runeKey} className={className0} onMouseDown={_onMouseDown}>{rune.text}</span>
+    )
+  }
 }
 
 export const PostDate = (props) => {

--- a/src/components/cells/ContentRenderer.js
+++ b/src/components/cells/ContentRenderer.js
@@ -44,6 +44,8 @@ export class Runes extends Component {
   }
 }
 
+const _runeAttrs = ['foreground', 'background', 'blink', 'highlight']
+
 export class RuneCore extends Component {
   static getClassNamesFromRune = (rune) => {
     let classNames0 = [styles['rune']]
@@ -58,12 +60,13 @@ export class RuneCore extends Component {
     if(color0.background) {
       classNames0.push(styles['c'+color0.background])
     }
-    return classNames0
+    const twoColors = rune.color1 && _runeAttrs.some((attr) => color0[attr] !== rune.color1[attr])
+    return [classNames0, twoColors]
   }
 
   render = () => {
     const {rune, rowIndex, idx, onMouseDown} = this.props
-    let classNames0 = RuneCore.getClassNamesFromRune(rune)
+    let [classNames0] = RuneCore.getClassNamesFromRune(rune)
     if(rune.pullright){
       classNames0.push(styles['pull-right'])
     }

--- a/src/components/cells/ContentRenderer.js
+++ b/src/components/cells/ContentRenderer.js
@@ -59,6 +59,9 @@ export class RuneCore extends Component {
     if(color.background) {
       classNames.push(styles[part+'c'+color.background])
     }
+    if(color.blink) {
+      classNames.push(styles[part+'c5'])
+    }
     return classNames
   }
 

--- a/src/components/cells/ContentRenderer.module.css
+++ b/src/components/cells/ContentRenderer.module.css
@@ -99,6 +99,7 @@
     position: absolute;
     width: 1ch;
     clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
+    z-index: -1; /* Draw below the selectable text */
 }
 .halves-group > .halves:after { /* The right half of a character; not selectable */
     content: attr(data-text);
@@ -106,6 +107,7 @@
     margin-left: -1ch;
     text-indent: -1ch;
     clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
+    z-index: -2; /* Draw below the selectable text */
 }
 
 .rune {
@@ -119,6 +121,12 @@
 }
 .extend {
     width: 100%;
+}
+
+.halves-group { /* Container for a .halves rune group */
+    /* Prevent .halves elements from being drawn below the background */
+    position: relative;
+    z-index: 2;
 }
 
 .calc {

--- a/src/components/cells/ContentRenderer.module.css
+++ b/src/components/cells/ContentRenderer.module.css
@@ -6,88 +6,106 @@
     color: #ffff00
 }
 
-.c30 { /* foreground-black */
+.c30, .c30:before, .rc30:after { /* foreground-black */
     color: #000000;
 }
 
-.c31 { /* foreground-red */
+.c31, .c31:before, .rc31:after { /* foreground-red */
     color: #cc0000;
 }
 
-.c32 { /* foreground-green */
+.c32, .c32:before, .rc32:after { /* foreground-green */
     color: #00cc00;
 }
 
-.c33 { /* foreground-yellow */
+.c33, .c33:before, .rc33:after { /* foreground-yellow */
     color: #cccc00;
 }
-.c34 { /* foreground-blue */
+.c34, .c34:before, .rc34:after { /* foreground-blue */
     color: #0000cc;
 }
-.c35 { /* foreground-magenta */
+.c35, .c35:before, .rc35:after { /* foreground-magenta */
     color: #cc00cc;
 }
-.c36 { /* foreground-cyan */
+.c36, .c36:before, .rc36:after { /* foreground-cyan */
     color: #00cccc;
 }
-.c37 { /* foreground-white */
+.c37, .c37:before, .rc37:after { /* foreground-white */
     color: #cccccc;
 }
 
-.h30 { /* foreground-black */
+.h30, .h30:before, .rh30:after { /* foreground-black */
     color: #888888;
 }
 
-.h31 { /* foreground-red */
+.h31, .h31:before, .rh31:after { /* foreground-red */
     color: #ff0000;
 }
 
-.h32 { /* foreground-green */
+.h32, .h32:before, .rh32:after { /* foreground-green */
     color: #00ff00;
 }
 
-.h33 { /* foreground-yellow */
+.h33, .h33:before, .rh33:after { /* foreground-yellow */
     color: #ffff00;
 }
-.h34 { /* foreground-blue */
+.h34, .h34:before, .rh34:after { /* foreground-blue */
     color: #0000ff;
 }
-.h35 { /* foreground-magenta */
+.h35, .h35:before, .rh35:after { /* foreground-magenta */
     color: #ff00ff;
 }
-.h36 { /* foreground-cyan */
+.h36, .h36:before, .rh36:after { /* foreground-cyan */
     color: #00ffff;
 }
-.h37 { /* foreground-white */
+.h37, .h37:before, .rh37:after { /* foreground-white */
     color: #ffffff;
 }
 
-.c40 {
+.c40, .c40:before, .rc40:after {
     background-color: #000000;
 }
 
-.c41 {
+.c41, .c41:before, .rc41:after {
     background-color: #cc0000;
 }
 
-.c42 {
+.c42, .c42:before, .rc42:after {
     background-color: #00cc00;
 }
 
-.c43 {
+.c43, .c43:before, .rc43:after {
     background-color: #cccc00;
 }
-.c44 {
+.c44, .c44:before, .rc44:after {
     background-color: #0000cc;
 }
-.c45 {
+.c45, .c45:before, .rc45:after {
     background-color: #cc00cc;
 }
-.c46 {
+.c46, .c46:before, .rc46:after {
     background-color: #00cccc;
 }
-.c47 {
+.c47, .c47:before, .rc47:after {
     background-color: #cccccc;
+}
+
+.halves-group > .halves { /* Container for the two halves of a character; selectable */
+    color: transparent;
+    background: transparent;
+}
+.halves-group > .halves:before { /* The left half of a character; not selectable */
+    content: attr(data-text);
+    position: absolute;
+    width: 1ch;
+    clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
+}
+.halves-group > .halves:after { /* The right half of a character; not selectable */
+    content: attr(data-text);
+    position: absolute;
+    margin-left: -1ch;
+    text-indent: -1ch;
+    clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
 }
 
 .rune {

--- a/src/components/cells/ContentRenderer.module.css
+++ b/src/components/cells/ContentRenderer.module.css
@@ -90,6 +90,10 @@
     background-color: #cccccc;
 }
 
+.hide-blink .c5, .hide-blink .c5:before, .hide-blink .rc5:after { /* blink */
+    color: transparent;
+}
+
 .halves-group > .halves { /* Container for the two halves of a character; selectable */
     color: transparent;
     background: transparent;

--- a/src/components/cells/Edit.js
+++ b/src/components/cells/Edit.js
@@ -57,21 +57,10 @@ export class EditCore extends Component {
         return (<RuneCore rune={rune} rowIndex={selectedRow} idx={idx} onMouseDown={onMouseDown} />)
     }
 
-    let classNames0 = [styles['rune']]
-    if(rune.color0.foreground) {
-      if(rune.color0.highlight) {
-        classNames0.push(styles['h'+rune.color0.foreground])
-      } else {
-        classNames0.push(styles['c'+rune.color0.foreground])
-      }
-    }
-    if(rune.color0.background) {
-      classNames0.push(styles['c'+rune.color0.background])
-    }
+    let classNames0 = RuneCore.getClassNamesFromRune(rune)
     if(rune.pullright){
       classNames0.push(styles['pull-right'])
     }
-
     classNames0.push(styles['input'])
 
     let theStyles={

--- a/src/components/cells/Edit.js
+++ b/src/components/cells/Edit.js
@@ -57,7 +57,7 @@ export class EditCore extends Component {
         return (<RuneCore rune={rune} rowIndex={selectedRow} idx={idx} onMouseDown={onMouseDown} />)
     }
 
-    let classNames0 = RuneCore.getClassNamesFromRune(rune)
+    let [classNames0] = RuneCore.getClassNamesFromRune(rune)
     if(rune.pullright){
       classNames0.push(styles['pull-right'])
     }

--- a/src/reducers/articlePage.js
+++ b/src/reducers/articlePage.js
@@ -360,6 +360,7 @@ const _parseRegularComment = (each) => {
   let contentRunes = (each.content && each.content.length > 0) ? each.content[0] : []
   if(contentRunes.length > 0) {
     contentRunes[0].color0.foreground = COLOR_FOREGROUND_YELLOW
+    delete contentRunes[0].color1
     runes = runes.concat(contentRunes)
   }
 


### PR DESCRIPTION
## Why

Improve the completeness of the support for BBS text attributes.
提昇對 BBS 文字屬性的支援的完整度。

However, in the row under the cursor in the editor, characters with two colors are still not supported.
不過還不支援編輯器中游標所在行的雙色字元。

In addition, to make ANSI arts displayed properly, the current setting of line height and character spacing still needs more tweaking.
此外，若要使 ANSI 圖正確顯示，目前的行高與字元距離設定仍需再調整。

## How

See commit message for details.
詳情請見 commit 訊息。

Below is an explanation of how these effects are achieved.
以下是這些顯示效果是如何達到的的說明。

### Single Characters with Two Colors 一字雙色

#### Rendering result of an example text with this effect 帶有此效果的範例文字的彩現結果:
![1-char-2-colors all layers](https://user-images.githubusercontent.com/37586669/130376076-10fcc4e6-7a26-4cb2-a584-d05bf621dea7.png)
This effect is achieved by using multiple layers 此效果是利用多個圖層達到的:
- Text layer 文字層 (transparent texts are represented here by a semi-transparent layer 透明文字在此以半透明圖層表示)
![1-char-2-colors text layer](https://user-images.githubusercontent.com/37586669/130377489-9fb710ef-2afa-4835-bf93-bd4cbf17d79a.png)
    - The texts are selectable. 文字可被反白選取。
    - Applied CSS classes 作用於此的 CSS 類別: `.c<num>`, `.h<num>`, & `.halves`
-  `.halves-group` container `.halves-group` 容器 (represented here by dashed outlines 在此以虛線外框表示)
![1-char-2-colors halves-group container](https://user-images.githubusercontent.com/37586669/130395350-09dd4709-8b0e-4ddc-b514-3fac7883007f.png)
    - Applied CSS class 作用於此的 CSS 類別: `.halves-group`
    - Characters are displayed as having two colors only inside these containers. 只有這些容器中的字元會顯示爲雙色字元。
- `:before` pseudo element layer (left half) `:before` 僞元素層（左半）
![1-char-2-colors :before layer](https://user-images.githubusercontent.com/37586669/130376795-279d8d5b-15a8-456d-a949-2261a9eb8c1a.png)
    - The texts are not selectable. 文字無法被反白選取。
    - Each character is clipped with `width` + `clip-path`. 使用 `width` + `clip-path` 裁切各個字元。
    - This layer is drawn below the text layer. 此層被畫在文字層之下。
    - Applied CSS classes 作用於此的 CSS 類別: `.c<num>:before`, `.h<num>:before`, & `.halves:before`
- `:after` pseudo element layer (right half) `:after` 僞元素層（右半）
![1-char-2-colors :after layer](https://user-images.githubusercontent.com/37586669/130376805-6be7e9c9-42b0-45f9-8047-221c98a13a93.png)
    - The texts are not selectable. 文字無法被反白選取。
    - Each character is clipped with `text-indext` + `clip-path`. 使用 `text-indent` + `clip-path` 裁切各個字元。
    - This layer is drawn below the `:before` layer. 此層被畫在 `:before` 層之下。
    - Applied CSS classes 作用於此的 CSS 類別: `.rc<num>:after`, `.rh<num>:after`, & `.halves:after`

### Text Blinking 文字閃爍

Inspired by the implementation of PttChrome. 受 PttChrome 的實作方式啟發。
![text blinking with class display](https://user-images.githubusercontent.com/37586669/130438801-2020ff68-b486-4ec8-8085-80cdcced7d8e.gif)
- Applied CSS classes 作用於此的 CSS 類別: `.c5`, `.c5:before`, & `.rc5:after`
- Controlling CSS class 調控其的 CSS 類別: `.hide-blink`

## Related Issues

None. 無。

## References

- Source of examples 範例出處: `#1WsI__Ix (WhoAmI) [pttdocker.test] [討論] 特殊色彩效果、控制碼`
    https://www.devptt.site/board/WhoAmI/article/M.1624846335.A.4BB
- More examples 更多範例: `#1Weyzz0l (WhoAmI) [pttdocker.test] [討論] Test-6`
    https://www.devptt.site/board/WhoAmI/article/M.1621348221.A.02F
- Ptt-official-app/go-openbbsmiddleware `types/color.go` `type Color`
    https://github.com/Ptt-official-app/go-openbbsmiddleware/blob/8d41994a26af30246cd360608724a6bdbf37b1c7/types/color.go#L3-L9
- robertabcd/PttChrome `src/js/term_buf.js` `TermBuf.prototype.notify()`
    https://github.com/robertabcd/PttChrome/blob/88e3562e6536cc0a91dbbb9f65e59036e4b73b79/src/js/term_buf.js#L820