### PR TITLE
bug fix: fix UI layout of search bar.

### DIFF
--- a/src/components/ArticlesPage.js
+++ b/src/components/ArticlesPage.js
@@ -113,7 +113,7 @@ export default (props) => {
   }
 
   const onSearchSubmit = () => {
-    setSearching(true)
+    searchTitle === '' ? setSearching(false) : setSearching(true)
     // clear articles
     // load more
     doArticlesPage.GetArticles(myID, bid, searchTitle, null, true, false)

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -6,6 +6,7 @@
 
 .searchText {
   display: block;
+  width: 100%;
   flex: 1 1 auto;
 
   padding: 0 0;


### PR DESCRIPTION
## Why
窄視窗時SearchBar的Layout會跑掉～

## How
1. fix the css module.
2. 讓Search空字串時會自動把取消按鈕移除

result:
<img width="804" alt="Screenshot 2021-09-21 at 22 31 17" src="https://user-images.githubusercontent.com/4489005/134250627-b601fdbf-3185-4792-af29-a746092acc02.png">

## Related Issues
#126 

## References
None
