### PR TITLE
improving font-weight for double-color

### DIFF
--- a/src/components/InitConsts.tsx
+++ b/src/components/InitConsts.tsx
@@ -34,11 +34,11 @@ export default (props: Props) => {
 
         let rect = ref.current.getBoundingClientRect()
         let theStyle = getComputedStyle(ref.current)
-        console.log('InitConsts: width:', rect.width, 'height:', rect.height, 'fontSize:', theStyle.fontSize, 'fontFamily:', theStyle.fontFamily)
-        InitCONSTS(windowWidth, rect.height, isMobile, fontSize, scale, screenWidth)
+        let lineHeight = rect.height - 0.5
+        console.log('InitConsts: width:', rect.width, 'height:', rect.height, 'windowWidth:', windowWidth, 'lineHeight:', lineHeight, 'fontSize:', theStyle.fontSize, 'fontFamily:', theStyle.fontFamily)
+        InitCONSTS(windowWidth, lineHeight, isMobile, fontSize, scale, screenWidth)
         setIsInitConsts(true)
     }, [ref.current, isInitConsts])
-
 
     return (<span ref={ref} className={styles['root']} style={style}>█</span>)
 }

--- a/src/components/cells/ContentRenderer.module.css
+++ b/src/components/cells/ContentRenderer.module.css
@@ -114,6 +114,12 @@
     z-index: -2; /* Draw below the selectable text */
 }
 
+.halves-group { /* Container for a .halves rune group */
+    /* Prevent .halves elements from being drawn below the background */
+    position: relative;
+    z-index: 1;
+}
+
 .rune {
     white-space: pre;
     height: 100%;
@@ -125,12 +131,6 @@
 }
 .extend {
     width: 100%;
-}
-
-.halves-group { /* Container for a .halves rune group */
-    /* Prevent .halves elements from being drawn below the background */
-    position: relative;
-    z-index: 2;
 }
 
 .calc {

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@ body {
     line-height: 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    font-weight: 500;
 }
 
 code {


### PR DESCRIPTION
## Why

Originally there was some offset for █ 
and a thin line appeared in the bottom
when displaying big-H.

█    █
███
█    █

Improving the visual by slightly shortening the line-height
and slightly increasing the font-weight.

Also need to be aware of the bottom of "g" and "y".

## How

## Related Issues

## References

https://www.devptt.dev/board/WhoAmI/article/M.1673664487.A.661