### PR TITLE
refactor(Rune): drop halves-group container for two-color chars

### DIFF
--- a/src/components/cells/ContentRenderer.module.css
+++ b/src/components/cells/ContentRenderer.module.css
@@ -94,30 +94,24 @@
     color: transparent;
 }
 
-.halves-group > .halves { /* Container for the two halves of a character; selectable */
+.halves { /* Container for the two halves of a character; selectable */
+    position: relative;
+    /* Prevent .halves elements from being drawn below the background */
+    z-index: 1;
     color: transparent;
     background: transparent;
 }
-.halves-group > .halves:before { /* The left half of a character; not selectable */
+.halves:before, .halves:after { /* The halves of a character; not selectable */
     content: attr(data-text);
     position: absolute;
-    width: 1ch;
-    clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
+    left: 0px; /* for the left half */
+    width: 50%;
+    overflow: hidden;
     z-index: -1; /* Draw below the selectable text */
 }
-.halves-group > .halves:after { /* The right half of a character; not selectable */
-    content: attr(data-text);
-    position: absolute;
-    margin-left: -1ch;
-    text-indent: -1ch;
-    clip-path: inset(-0.5px); /* 0px causes wierd border line on Chrome and Edge */
-    z-index: -2; /* Draw below the selectable text */
-}
-
-.halves-group { /* Container for a .halves rune group */
-    /* Prevent .halves elements from being drawn below the background */
-    position: relative;
-    z-index: 1;
+.halves:after { /* The right half of a character; not selectable */
+    left: 50%;
+    text-indent: -100%;
 }
 
 .rune {

--- a/src/components/cells/Rune.tsx
+++ b/src/components/cells/Rune.tsx
@@ -23,20 +23,17 @@ export default (props: Props) => {
         rowIndex = rowIndex || 0
         onMouseDown(e, rowIndex, idx)
     }
+    classNames0.push(...classNamesGroup)
+    let className0 = classNames0.join(' ')
     if (isTwoColor) {
-        classNamesGroup.push(styles['halves-group'])
-        let classNameGroup = classNamesGroup.join(' ')
-        let className0 = classNames0.join(' ')
         return (
-            <span className={classNameGroup}>
+            <>
                 {[...rune.text].map((ch, idx) => (
                     <span key={`${runeKey}-${idx}`} className={className0} onMouseDown={_onMouseDown} data-text={ch}>{ch}</span>
                 ))}
-            </span>
+            </>
         )
     } else {
-        classNames0.push(...classNamesGroup)
-        let className0 = classNames0.join(' ')
         return (
             <span key={runeKey} className={className0} onMouseDown={_onMouseDown}>{rune.text}</span>
         )


### PR DESCRIPTION
The two-color-word effect, before and after this change. They should look the same despite the difference of HTML layout.

![image](https://github.com/Ptt-official-app/demo-pttbbs/assets/37586669/cb1e8467-bfcc-4638-8907-35e383d22170)

## Why

By the PR of PttChrome mentioned below, it is known that two-color characters are possible without using an outer `<span>`.

## How

* `src/components/cells/Rune.tsx`
    * drop the use of CSS class `.halves-group`
    * use `react.Fragment` (`<> </>`) to replace the previous outer `<span>`
    * make `classNamesGroup` (for styling the previous outer `<span>`) appended to `classNames0` (for styling each two-color char)
* `src/components/cells/ContentRenderer.module.css`
    * drop CSS class `.halves-group`
    * replace `.halves` styling with `.o` styling from the PttChrome PR

## Related Issues

Ptt-official-app/demo-pttbbs#122, where the support of two-color character display has been introduced.

## References

robertabcd/PttChrome#102